### PR TITLE
Don't export GHC.Event if it is compiled by GHCJS.

### DIFF
--- a/base-noprelude.cabal
+++ b/base-noprelude.cabal
@@ -234,5 +234,6 @@ library
             GHC.Conc.Windows,
             GHC.Windows
     else
+      if !impl(ghcjs)
         reexported-modules:
             GHC.Event


### PR DESCRIPTION
Fixes #4 .
