### PR TITLE
Don't reexport Data.Typeable.Internal

### DIFF
--- a/base-noprelude.cabal
+++ b/base-noprelude.cabal
@@ -108,7 +108,6 @@ library
         Data.Type.Coercion,
         Data.Type.Equality,
         Data.Typeable,
-        Data.Typeable.Internal,
         Data.Unique,
         Data.Version,
         Data.Void,


### PR DESCRIPTION
It's really an internal module and it is no longer exported in base 4.10