### PR TITLE
Updates for base 4.14.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist/
+dist-newstyle
 *~

--- a/base-noprelude.cabal
+++ b/base-noprelude.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                base-noprelude
-version:             4.12.0.0
+version:             4.14.0.0
 
 synopsis:            "base" package sans "Prelude" module
 homepage:            https://github.com/hvr/base-noprelude
@@ -14,7 +14,7 @@ build-type:          Simple
 description:
     This package simplifies defining custom "Prelude"s without having
     to use @-XNoImplicitPrelude@ by re-exporting the full module-hierarchy of
-    the [base-4.12.0.0](https://hackage.haskell.org/package/base-4.12.0.0)
+    the [base-4.14.0.0](https://hackage.haskell.org/package/base-4.14.0.0)
     package /except/ for the "Prelude" module.
     .
     An usage example for such a "Prelude"-replacement is available with
@@ -35,10 +35,10 @@ source-repository head
     location: https://github.com/hvr/base-noprelude.git
 
 library
-    build-depends:       base ==4.12.0.0
+    build-depends:       base ==4.14.0.0
     default-language:    Haskell2010
 
-    -- re-exported modules copied from base-4.12.0.0's exposed-modules
+    -- re-exported modules copied from base-4.14.0.0's exposed-modules
     reexported-modules:
       , Control.Applicative
       , Control.Arrow
@@ -162,6 +162,7 @@ library
       , GHC.Foreign
       , GHC.ForeignPtr
       , GHC.GHCi
+      , GHC.GHCi.Helpers
       , GHC.Generics
       , GHC.IO
       , GHC.IO.Buffer
@@ -189,6 +190,7 @@ library
       , GHC.IOArray
       , GHC.IORef
       , GHC.Int
+      , GHC.Ix
       , GHC.List
       , GHC.Maybe
       , GHC.MVar


### PR DESCRIPTION
#11

Hopefully correct. I updated the reexported-modules based on https://hackage.haskell.org/package/base-4.14.0.0/base.cabal

I also ignored `dist-newstyle` as cabal 3.2 was creating these directories as I tested.