### PR TITLE
Update to 4.14.1.0

### DIFF
--- a/base-noprelude.cabal
+++ b/base-noprelude.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                base-noprelude
-version:             4.12.0.0
+version:             4.14.1.0
 
 synopsis:            "base" package sans "Prelude" module
 homepage:            https://github.com/hvr/base-noprelude
@@ -14,7 +14,7 @@ build-type:          Simple
 description:
     This package simplifies defining custom "Prelude"s without having
     to use @-XNoImplicitPrelude@ by re-exporting the full module-hierarchy of
-    the [base-4.12.0.0](https://hackage.haskell.org/package/base-4.12.0.0)
+    the [base-4.14.1.0](https://hackage.haskell.org/package/base-4.14.1.0)
     package /except/ for the "Prelude" module.
     .
     An usage example for such a "Prelude"-replacement is available with
@@ -35,10 +35,10 @@ source-repository head
     location: https://github.com/hvr/base-noprelude.git
 
 library
-    build-depends:       base ==4.12.0.0
+    build-depends:       base ==4.14.1.0
     default-language:    Haskell2010
 
-    -- re-exported modules copied from base-4.12.0.0's exposed-modules
+    -- re-exported modules copied from base-4.14.1.0's exposed-modules
     reexported-modules:
       , Control.Applicative
       , Control.Arrow
@@ -162,6 +162,7 @@ library
       , GHC.Foreign
       , GHC.ForeignPtr
       , GHC.GHCi
+      , GHC.GHCi.Helpers
       , GHC.Generics
       , GHC.IO
       , GHC.IO.Buffer
@@ -189,6 +190,7 @@ library
       , GHC.IOArray
       , GHC.IORef
       , GHC.Int
+      , GHC.Ix
       , GHC.List
       , GHC.Maybe
       , GHC.MVar


### PR DESCRIPTION
Hello @hvr 

could you please consider merging this and publishing this version on hackage?
It would ease the migration of our project to ghc 8.10.4
It might make sense to merge https://github.com/haskell-hvr/base-noprelude/pull/12 first and rebase this PR on top of that..
